### PR TITLE
Fix array type handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "com.zendesk",
-  version := "0.0.1-SNAPSHOT",
+  version := "0.0.2-SNAPSHOT",
   
   scalaVersion := "2.12.1",
   scalacOptions ++= Seq("-feature"),


### PR DESCRIPTION
RichTagType is throwing
`java.lang.ClassNotFoundException: no Java class corresponding to class Array`
when an Scala array type is passed in.

Fixes:
* Get Java class directly from Scala type without first casting to ClassSymbol (as this blows up when class is array)
* Explicit check for array type, and return GenericArrayType if array has type parameters
* Expand handling of primitives

There's some modest risk with this change, so also bump version number.