### PR TITLE
Add “registerCaseClassCoders” methods to implicit scope

### DIFF
--- a/core/src/main/boilerplate/com/zendesk/scalaflow/sugar/CaseClassOps.scala.template
+++ b/core/src/main/boilerplate/com/zendesk/scalaflow/sugar/CaseClassOps.scala.template
@@ -10,7 +10,7 @@ import scala.reflect.runtime.universe._
 import com.zendesk.scalaflow.coders._
 import TypeTagOps._
 
-object CaseClassCoders {
+trait CaseClassOps {
 
   implicit class RichCaseClassPipeline(pipeline: Pipeline) {
 
@@ -68,3 +68,5 @@ object CaseClassCoders {
     ]
   }
 }
+
+object CaseClassOps extends CaseClassOps

--- a/core/src/main/scala/com/zendesk/scalaflow/package.scala
+++ b/core/src/main/scala/com/zendesk/scalaflow/package.scala
@@ -2,7 +2,8 @@ package com.zendesk
 
 import com.zendesk.scalaflow.sugar._
 
-package object scalaflow extends CollectionOps
+package object scalaflow extends CaseClassOps
+  with CollectionOps
   with DurationOps
   with KVCollectionOps
   with MiscOps

--- a/core/src/test/scala/com/zendesk/scalaflow/sugar/CaseClassOpsSpec.scala
+++ b/core/src/test/scala/com/zendesk/scalaflow/sugar/CaseClassOpsSpec.scala
@@ -6,14 +6,17 @@ import com.google.cloud.dataflow.sdk.transforms.Create
 
 import org.scalatest.{FlatSpec, Matchers}
 
-import CaseClassCoders._
+import CaseClassOps._
 
-case class Foo()
-case class Bar(name: String)
-case class Qux(name: String, age: Int)
-case class Wibble(foo: Foo, bar: Bar, qux: Qux)
+object CaseClassOpsSpec {
+  case class Foo()
+  case class Bar(name: String)
+  case class Qux(name: String, age: Int)
+  case class Wibble(foo: Foo, bar: Bar, qux: Qux)
+}
 
-class CaseClassCoderSpec extends FlatSpec with Matchers {
+class CaseClassOpsSpec extends FlatSpec with Matchers {
+  import CaseClassOpsSpec._
 
   behavior of "CaseClassCoders"
 


### PR DESCRIPTION
### Description 

We had forgotten to include CaseClassCoders in the implicit scope, d'oh!

### Details

* Rename CaseClassCoder to CaseClassOps and change to trait
* Actually include in implicit scope (package object now extends it)
* Rename spec to match
* Move test case classes out of package scope